### PR TITLE
fix: NodeGroup && make non-nullable for eks-primary-security-group-id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_eks_node_group" "l2geth" {
 
   version         = var.k8s-version
   ami_type        = var.ami-type
-  release_version = var.ami-version
+  instance_types = [var.instance-type]
 
   # the default is 20, that's should enough
   # disk_size = 20
@@ -80,7 +80,7 @@ resource "aws_eks_node_group" "themis" {
 
   version         = var.k8s-version
   ami_type        = var.ami-type
-  release_version = var.ami-version
+  instance_types = [var.instance-type]
 
   # the default is 20, that's should enough
   # disk_size = 20

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,7 @@ variable "k8s-ns-name" {
 }
 
 variable "eks-primary-security-group-id" {
-  description = "the primary security group id of your eks, it will added to node group"
-  nullable    = true
+  description = "the primary security group id of your eks, it will added to node group. if set as null, creation of node group will be failed."
 }
 
 variable "k8s-version" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "l2geth-node-group-taint" {
   default = {
     "l2geth" : {
       effect = "NO_SCHEDULE"
-      key    = "sequencer.metis.io"
+      key    = "node.metis.io"
       value  = "l2geth"
     }
   }
@@ -76,7 +76,7 @@ variable "themis-node-group-taint" {
   default = {
     "themis" : {
       effect = "NO_SCHEDULE"
-      key    = "sequencer.metis.io"
+      key    = "node.metis.io"
       value  = "themis"
     }
   }


### PR DESCRIPTION
# InstanceType
In the origin terraform script, there were no instance_type reference code. so, when I run this script, its instance type was t3.medium(that is too small than default value). 

# eks-primary-security-group-id
I suggest you to set non-nullable for eks-primary-security-group-id. 
because if it's not set(or set as null), the creation of node group could not be success cause of blocking by security group.


# taint
and also, I changed default value of variable for taint.

### Before
`  default = {
    "themis" : {
      effect = "NO_SCHEDULE"
      key    = "sequencer.metis.io"
      value  = "themis"
    }
  }`
  
### After
`  default = {
    "themis" : {
      effect = "NO_SCHEDULE"
      key    = "node.metis.io"
      value  = "themis"
    }
  }`
  

In [metis-chart README.md](https://github.com/MetisProtocol/metis-charts/blob/a30426f17270ebc2893cefb304ecff383865edc5/charts/metis-node/README.md), it describes default setup for affinity using the key of "node.metis.io". 
I think it may generate confusion about deploy sequencer.
